### PR TITLE
[Soh Jun Qi] Change command format for certain commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -138,9 +138,9 @@ Daily Fat intake: 55 g
 
 Changes the current active diet plan to the newly specified plan.
 
-**Format:** `start p/plan`
+**Format:** `plan active p/plan`
 
-**Example:** `start p/1`
+**Example:** `plan active p/1`
 
 **Expected output:**
 
@@ -155,7 +155,7 @@ Daily Fat intake: 55 g
 
 Displays a list of available diet plans.
 
-**Format:** `plans`
+**Format:** `plan list`
 
 **Expected output:**
 
@@ -168,9 +168,9 @@ Here are the available diet plans:
 
 Displays information about a particular diet plan.
 
-**Format:** `plan \tID`
+**Format:** `plan t/ID`
 
-**Example:** `plan t\1`
+**Example:** `plan t/1`
 
 **Expected output:**
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -224,8 +224,8 @@ Action | Format, Examples
 **Update weight, height and ideal weight** | `bmi update h/height(cm) w/weight(kg) i/ideal_weight(kg)`<br> e.g., `bmi update h/170 w/70 i/80`
 **Get diet recommendation based on current BMI** | `plan recommended`
 **View active diet plan** | `plan current`
-**Select active diet plan** | `start p/plan`<br> e.g., `start p/1`
-**List all available diet plans** | `plans`
-**View information about a particular diet plan** | `plan \tID​`<br> e.g.,`plan t\1`
+**Select active diet plan** | `plan active p/plan`<br> e.g., `plan active p/1`
+**List all available diet plans** | `plan list`
+**View information about a particular diet plan** | `plan t/ID​`<br> e.g.,`plan t/1`
 **Input carbohydrates, fats and protein intake** | `food d/DATE n/NAME p/PROTEINS c/CARBOHYDRATES f/FATS`<br> e.g., `food d/today n/tomatoes p/10 c/10 f/10`
 **List food intake for certain days** | `food query d/DATE`<br> e.g., `food query d/today`


### PR DESCRIPTION
The commands for starting a new plan, listing all diet plans, and displaying information about specific plans have different formats. This may be confusing to the user.

Let's standardize them to start with 'plan'.