### PR TITLE
[Song Soon Wee] Fix old food intake items from updating their values

### DIFF
--- a/src/main/java/seedu/address/model/food/Food.java
+++ b/src/main/java/seedu/address/model/food/Food.java
@@ -150,8 +150,8 @@ public class Food {
 
     @Override
     public String toString() {
-        String result = this.name + " (Protein: " + this.proteins + "g, Carbohydrates: " + this.carbos + "g, Fats: "
-                + this.fats + "g)";
+        String result = this.name + " (Carbohydrates: " + this.carbos + "g, Fats: " + this.fats + "g, Proteins: "
+                + this.proteins + "g)";
         return result;
     }
 }

--- a/src/main/java/seedu/address/model/food/FoodIntake.java
+++ b/src/main/java/seedu/address/model/food/FoodIntake.java
@@ -15,11 +15,12 @@ public class FoodIntake {
      * Creates a FoodIntake object representing the Food consumed at a particular date and time.
      *
      * @param date LocalDateTime of when the food was eaten
-     * @param food The related Food object that was consumed
+     * @param temporaryFood The related Food object that was consumed
      */
-    public FoodIntake(LocalDate date, Food food) {
+    public FoodIntake(LocalDate date, Food temporaryFood) {
         this.date = date;
-        this.food = food;
+        this.food = new Food(temporaryFood.getName(), temporaryFood.getCarbos(), temporaryFood.getFats(),
+                temporaryFood.getProteins());
     }
 
     public Food getFood() {


### PR DESCRIPTION
Add a fix to prevent older food intake items from having their nutrients value updated. 

Below is the updated scenario when user is performing action to the food intake: 
- When a certain food item is deleted, any new food intake adding it will fail. 
- When a certain food item is updated, old food intake will retain their old data, while for new food intake records, they will use the newer data. 

Contributes to #74.