### PR TITLE
[Song Soon Wee] Update AddFoodIntake command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddFoodIntakeCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -19,31 +20,151 @@ public class AddFoodIntakeCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Success adding food item (";
 
-    public static final String MESSAGE_FAILURE = "Suggested food item not found. Please add it into food list before "
-            + "adding food intake.";
-
-    private final String foodString;
+    public static final String MESSAGE_FAILURE_CREATE_FOOD_REQ = "Suggested food item not found. Please append at "
+            + "least 1 nutrient value to add the food item. (Eg. c/CARBOS(g) or f/FATS(g) or p/PROTEINS(g) ";
 
     private final LocalDate date;
+
+    private final TemporaryFoodDescriptor tempFoodDescriptor;
 
     /**
      * Creates a AddFoodIntake command to run the Macronutrients Tracker.
      */
-    public AddFoodIntakeCommand(LocalDate date, String food) {
-        this.foodString = food;
+    public AddFoodIntakeCommand(LocalDate date, TemporaryFoodDescriptor tempFoodDescriptor) {
         this.date = date;
+        this.tempFoodDescriptor = tempFoodDescriptor;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        int index = model.getUniqueFoodList().getFoodItemIndex(foodString);
+        int index = model.getUniqueFoodList().getFoodItemIndex(this.tempFoodDescriptor.getName().get());
+        boolean skipEditCheck = false;
 
+        //Food does not exist in Unique Food List, hence add the food item in.
         if (index == -1) {
-            throw new CommandException(MESSAGE_FAILURE);
+            Food newFood = createNewFood(this.tempFoodDescriptor);
+            model.addFoodItem(newFood);
+            index = model.getUniqueFoodList().getFoodList().size() - 1;
+            skipEditCheck = true;
         }
+
         Food food = model.getUniqueFoodList().getFoodList().get(index);
+        //Check for any edits made to the certain food item.
+        if (!skipEditCheck && (this.tempFoodDescriptor.getCarbos().isPresent()
+                || this.tempFoodDescriptor.getFats().isPresent()
+                || this.tempFoodDescriptor.getProteins().isPresent())) {
+            Food edittedFood = editCurrentFood(food, tempFoodDescriptor);
+            model.getUniqueFoodList().getFoodList().set(index, edittedFood);
+            model.addFoodIntake(this.date, edittedFood);
+            return new CommandResult(MESSAGE_SUCCESS + edittedFood + ") into food intake list.");
+        }
+
         model.addFoodIntake(this.date, food);
         return new CommandResult(MESSAGE_SUCCESS + food + ") into food intake list.");
+    }
+
+    /**
+     * Creates a new food item to add into unique food list and food intake.
+     *
+     * @param tempFoodDescriptor temporary Food item holder
+     * @return new food item
+     * @throws CommandException if no nutrient value is specified.
+     */
+    public Food createNewFood(TemporaryFoodDescriptor tempFoodDescriptor) throws CommandException {
+        String foodName = tempFoodDescriptor.getName().get();
+        //Default initialize all double values to 0.
+        Double newCarbos = 0.0;
+        Double newFats = 0.0;
+        Double newProteins = 0.0;
+        if (!tempFoodDescriptor.getCarbos().isPresent() && !tempFoodDescriptor.getFats().isPresent()
+                && !tempFoodDescriptor.getProteins().isPresent()) {
+            throw new CommandException(MESSAGE_FAILURE_CREATE_FOOD_REQ);
+        }
+        if (tempFoodDescriptor.getCarbos().isPresent()) {
+            newCarbos = tempFoodDescriptor.getCarbos().get();
+        }
+        if (this.tempFoodDescriptor.getFats().isPresent()) {
+            newFats = tempFoodDescriptor.getFats().get();
+        }
+        if (this.tempFoodDescriptor.getProteins().isPresent()) {
+            newProteins = tempFoodDescriptor.getProteins().get();
+        }
+        return new Food(foodName, newCarbos, newFats, newProteins);
+    }
+
+    /**
+     * Creates a new edited food item with its details edited.
+     *
+     * @param existingFood       existing food item
+     * @param tempFoodDescriptor temporary food item holder
+     * @return new edited food item
+     */
+    public Food editCurrentFood(Food existingFood, TemporaryFoodDescriptor tempFoodDescriptor) {
+        String foodName = this.tempFoodDescriptor.getName().get();
+        //Default initialize all double values to 0.
+        Double newCarbos = 0.0;
+        Double newFats = 0.0;
+        Double newProteins = 0.0;
+        if (tempFoodDescriptor.getCarbos().isPresent()
+                && existingFood.getCarbos() != tempFoodDescriptor.getCarbos().get()) {
+            newCarbos = tempFoodDescriptor.getCarbos().get();
+        } else {
+            newCarbos = existingFood.getCarbos();
+        }
+        if (tempFoodDescriptor.getFats().isPresent() && existingFood.getFats() != tempFoodDescriptor.getFats().get()) {
+            newFats = tempFoodDescriptor.getFats().get();
+        } else {
+            newFats = existingFood.getFats();
+        }
+        if (tempFoodDescriptor.getProteins().isPresent()
+                && existingFood.getProteins() != tempFoodDescriptor.getProteins().get()) {
+            newProteins = tempFoodDescriptor.getProteins().get();
+        } else {
+            newProteins = existingFood.getProteins();
+        }
+        return new Food(foodName, newCarbos, newFats, newProteins);
+    }
+
+    public static class TemporaryFoodDescriptor {
+        private String name;
+        private Double carbos;
+        private Double fats;
+        private Double proteins;
+
+        public TemporaryFoodDescriptor() {
+        }
+
+        public void setName(String name) {
+            this.name = name.toLowerCase();
+        }
+
+        public Optional<String> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        public void setCarbos(Double carbos) {
+            this.carbos = carbos;
+        }
+
+        public Optional<Double> getCarbos() {
+            return Optional.ofNullable(carbos);
+        }
+
+        public void setFats(Double fats) {
+            this.fats = fats;
+        }
+
+        public Optional<Double> getFats() {
+            return Optional.ofNullable(fats);
+        }
+
+        public void setProteins(Double proteins) {
+            this.proteins = proteins;
+        }
+
+        public Optional<Double> getProteins() {
+            return Optional.ofNullable(proteins);
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddFoodIntakeCommand.java
@@ -59,8 +59,8 @@ public class AddFoodIntakeCommand extends Command {
             Food edittedFood = editCurrentFood(food, tempFoodDescriptor);
             model.getUniqueFoodList().getFoodList().set(index, edittedFood);
             model.addFoodIntake(this.date, edittedFood);
-            return new CommandResult(MESSAGE_SUCCESS_FOOD_UPDATE + edittedFood + ".\n" +
-                    MESSAGE_SUCCESS + edittedFood + ") into food intake list.");
+            return new CommandResult(MESSAGE_SUCCESS_FOOD_UPDATE + edittedFood + ".\n"
+                    + MESSAGE_SUCCESS + edittedFood + ") into food intake list.");
         }
 
         model.addFoodIntake(this.date, food);

--- a/src/main/java/seedu/address/logic/commands/AddFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddFoodIntakeCommand.java
@@ -23,6 +23,8 @@ public class AddFoodIntakeCommand extends Command {
     public static final String MESSAGE_FAILURE_CREATE_FOOD_REQ = "Suggested food item not found. Please append at "
             + "least 1 nutrient value to add the food item. (Eg. c/CARBOS(g) or f/FATS(g) or p/PROTEINS(g) ";
 
+    public static final String MESSAGE_SUCCESS_FOOD_UPDATE = "Successfully edited food value to: ";
+
     private final LocalDate date;
 
     private final TemporaryFoodDescriptor tempFoodDescriptor;
@@ -57,7 +59,8 @@ public class AddFoodIntakeCommand extends Command {
             Food edittedFood = editCurrentFood(food, tempFoodDescriptor);
             model.getUniqueFoodList().getFoodList().set(index, edittedFood);
             model.addFoodIntake(this.date, edittedFood);
-            return new CommandResult(MESSAGE_SUCCESS + edittedFood + ") into food intake list.");
+            return new CommandResult(MESSAGE_SUCCESS_FOOD_UPDATE + edittedFood + ".\n" +
+                    MESSAGE_SUCCESS + edittedFood + ") into food intake list.");
         }
 
         model.addFoodIntake(this.date, food);

--- a/src/main/java/seedu/address/logic/parser/AddFoodIntakeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddFoodIntakeCommandParser.java
@@ -2,13 +2,17 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DATETIME_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CARBOS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FATS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROTEINS;
 
 import java.time.LocalDate;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddFoodIntakeCommand;
+import seedu.address.logic.commands.AddFoodIntakeCommand.TemporaryFoodDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 public class AddFoodIntakeCommandParser implements Parser<AddFoodIntakeCommand> {
@@ -20,24 +24,32 @@ public class AddFoodIntakeCommandParser implements Parser<AddFoodIntakeCommand> 
      */
     public AddFoodIntakeCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_DATE, PREFIX_NAME);
-
+                ArgumentTokenizer.tokenize(args, PREFIX_DATE, PREFIX_NAME, PREFIX_CARBOS, PREFIX_FATS, PREFIX_PROTEINS);
         if (!arePrefixesPresent(argMultimap, PREFIX_DATE, PREFIX_NAME)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddFoodIntakeCommand.MESSAGE_USAGE));
         }
 
         LocalDate date;
-        String name;
-
         try {
             date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_DATETIME_FORMAT,
                     AddFoodIntakeCommand.MESSAGE_USAGE));
         }
-        name = ParserUtil.parseFoodName(argMultimap.getValue(PREFIX_NAME).get());
-        return new AddFoodIntakeCommand(date, name);
+
+        TemporaryFoodDescriptor tempFoodDescriptor = new TemporaryFoodDescriptor();
+        tempFoodDescriptor.setName(ParserUtil.parseFoodName(argMultimap.getValue(PREFIX_NAME).get()));
+        if (argMultimap.getValue(PREFIX_CARBOS).isPresent()) {
+            tempFoodDescriptor.setCarbos(ParserUtil.parseDouble(argMultimap.getValue(PREFIX_CARBOS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_FATS).isPresent()) {
+            tempFoodDescriptor.setFats(ParserUtil.parseDouble(argMultimap.getValue(PREFIX_FATS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_PROTEINS).isPresent()) {
+            tempFoodDescriptor.setProteins(ParserUtil.parseDouble(argMultimap.getValue(PREFIX_PROTEINS).get()));
+        }
+        return new AddFoodIntakeCommand(date, tempFoodDescriptor);
     }
 
     /**

--- a/src/main/java/seedu/address/model/food/Food.java
+++ b/src/main/java/seedu/address/model/food/Food.java
@@ -12,7 +12,7 @@ public class Food {
     public static final String VALIDATION_POSITIVE_DOUBLE_REGEX = "(\\d*\\.?\\d+)";
     public static final String MESSAGE_CONSTRAINTS = "Food name can take any alphabets charcter and it should not be"
             + " blank.";
-    public static final String MESSAGE_DIGIT_CONSTRAINTS = "Double value input can only be positive and more than 0.";
+    public static final String MESSAGE_DIGIT_CONSTRAINTS = "Double value input can only be positive and at least 0.";
 
     private final String name;
     private double fats;


### PR DESCRIPTION
For user's convenience, AddFoodIntake command can now add new food items if the item is not existing within the unique food list and can edit food items value to the latest.

Current Implementation: 
- If a food item does not exist, food intake will add that food item into unique food list and as a food intake item in food intake list. (Command syntax: foodintake d/d MMM yyyy n/name c/CARBO(g) f/FAT(g) p/PROTEIN(g)) *At least 1 of c, f or p must be specified. Values that are not specified will be assigned 0 as default. 
- If a food item exists, food list will check for any difference in the food item values and update accordingly to the new change. (Command syntax: foodintake d/d MMM yyyy n/name c/CARBO(g) f/FAT(g) p/PROTEIN(g)) *c, f and p fields are optional. If none of the fields are specified, it just uses the food item within the unique food list. If any of c, f or p fields are specified, it will update the food items accordingly to the new value specified. 

Contributes to #84.