### PR TITLE
[Jason Lim] Add identifier for duplicate FoodIntakeList food names

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteFoodIntakeCommand.java
@@ -9,6 +9,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.food.FoodIntake;
 import seedu.address.model.food.FoodIntakeList;
+import seedu.address.model.food.exceptions.FoodIntakeNotFoundException;
 
 /**
  * Deletes a food intake identified using the food name and date.
@@ -45,15 +46,11 @@ public class DeleteFoodIntakeCommand extends Command {
         requireNonNull(model);
         FoodIntakeList foodIntakeList = model.getFoodIntakeList();
 
-        ObservableList<FoodIntake> temporaryList = foodIntakeList.getFoodIntakeList();
-
-        for (int i = 0; i < temporaryList.size(); i++) {
-            if (temporaryList.get(i).getFood().getName().equals(this.foodName)
-                    && temporaryList.get(i).getDate().isEqual(this.date)) {
-                foodIntakeList.deleteFoodIntake(i);
-                return new CommandResult(MESSAGE_DELETE_FOOD_SUCCESS + " " + this.foodName);
-            }
+        try {
+            foodIntakeList.deleteFoodIntake(this.date, this.foodName);
+            return new CommandResult(MESSAGE_DELETE_FOOD_SUCCESS + " " + this.foodName);
+        } catch (FoodIntakeNotFoundException exception) {
+            throw new CommandException(MESSAGE_DELETE_FOOD_FAILURE);
         }
-        throw new CommandException(MESSAGE_DELETE_FOOD_FAILURE);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteFoodIntakeCommand.java
@@ -4,10 +4,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
 
-import javafx.collections.ObservableList;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.food.FoodIntake;
 import seedu.address.model.food.FoodIntakeList;
 import seedu.address.model.food.exceptions.FoodIntakeNotFoundException;
 

--- a/src/main/java/seedu/address/logic/commands/UpdateFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateFoodIntakeCommand.java
@@ -73,9 +73,7 @@ public class UpdateFoodIntakeCommand extends Command {
             this.proteins = String.valueOf(currentFoodIntake.getFood().getProteins());
         }
 
-        newFoodIntake = new FoodIntake(this.date,
-                new Food(this.name, Double.parseDouble(this.carbos),
-                        Double.parseDouble(this.fats), Double.parseDouble(this.proteins)));
+        newFoodIntake = new FoodIntake(this.date, this.name, Double.parseDouble(this.carbos), Double.parseDouble(this.fats), Double.parseDouble(this.proteins));
         model.updateFoodIntake(index, newFoodIntake);
         return new CommandResult(MESSAGE_SUCCESS + "(" + this.name + ")");
     }

--- a/src/main/java/seedu/address/logic/commands/UpdateFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateFoodIntakeCommand.java
@@ -6,7 +6,6 @@ import java.time.LocalDate;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.food.Food;
 import seedu.address.model.food.FoodIntake;
 
 /**
@@ -73,7 +72,9 @@ public class UpdateFoodIntakeCommand extends Command {
             this.proteins = String.valueOf(currentFoodIntake.getFood().getProteins());
         }
 
-        newFoodIntake = new FoodIntake(this.date, this.name, Double.parseDouble(this.carbos), Double.parseDouble(this.fats), Double.parseDouble(this.proteins));
+        newFoodIntake = new FoodIntake(this.date, this.name,
+                Double.parseDouble(this.carbos), Double.parseDouble(this.fats),
+                Double.parseDouble(this.proteins));
         model.updateFoodIntake(index, newFoodIntake);
         return new CommandResult(MESSAGE_SUCCESS + "(" + this.name + ")");
     }

--- a/src/main/java/seedu/address/logic/parser/DeleteFoodIntakeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteFoodIntakeCommandParser.java
@@ -42,7 +42,7 @@ public class DeleteFoodIntakeCommandParser implements Parser<DeleteFoodIntakeCom
             throw new ParseException(String.format(MESSAGE_INVALID_DATETIME_FORMAT,
                     DeleteFoodIntakeCommand.MESSAGE_USAGE));
         }
-        foodName = ParserUtil.parseFoodName(argMultimap.getValue(PREFIX_NAME).get());
+        foodName = ParserUtil.parseFoodItemName(argMultimap.getValue(PREFIX_NAME).get());
         return new DeleteFoodIntakeCommand(date, foodName);
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -99,6 +99,22 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a {@code String name} into a {@code Name}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code name} is invalid.
+     */
+    public static String parseFoodItemName(String name) throws ParseException {
+        requireNonNull(name);
+        String trimmedName = name.trim();
+        if (!trimmedName.matches(Food.VALIDATION_CHAR_REGEX_IMPORT)
+                || !trimmedName.matches(Food.VALIDATION_WHITESPACE_REGEX)) {
+            throw new ParseException(Food.MESSAGE_CONSTRAINTS);
+        }
+        return trimmedName;
+    }
+
+    /**
      * Parses a {@code String ageString} into an Integer.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/seedu/address/logic/parser/UpdateFoodIntakeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UpdateFoodIntakeCommandParser.java
@@ -35,7 +35,7 @@ public class UpdateFoodIntakeCommandParser implements Parser<UpdateFoodIntakeCom
         String fats;
         String proteins;
 
-        String name = ParserUtil.parseFoodName(argMultimap.getValue(PREFIX_NAME).get());
+        String name = ParserUtil.parseFoodItemName(argMultimap.getValue(PREFIX_NAME).get());
         LocalDate date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
 
         if (!isPrefixPresent(argMultimap, PREFIX_CARBOS)) {

--- a/src/main/java/seedu/address/model/food/Food.java
+++ b/src/main/java/seedu/address/model/food/Food.java
@@ -9,12 +9,13 @@ public class Food {
     public static final double FAT_MULTIPLIER = 9; //Conversion to KCAL
     public static final String VALIDATION_WHITESPACE_REGEX = "[^\\s].*";
     public static final String VALIDATION_CHAR_REGEX = "[a-zA-Z ]*";
+    public static final String VALIDATION_CHAR_REGEX_IMPORT = "[a-zA-Z0-9 ]*";
     public static final String VALIDATION_POSITIVE_DOUBLE_REGEX = "(\\d*\\.?\\d+)";
     public static final String MESSAGE_CONSTRAINTS = "Food name can take any alphabets charcter and it should not be"
             + " blank.";
     public static final String MESSAGE_DIGIT_CONSTRAINTS = "Double value input can only be positive and at least 0.";
 
-    private final String name;
+    private String name;
     private double fats;
     private double carbos;
     private double proteins;
@@ -65,10 +66,21 @@ public class Food {
     }
 
     /**
-     * Returns true if a given string is a valid email.
+     * Returns true if a given string is a valid food name.
      */
     public static boolean isValidFoodName(String test) {
         if (test.matches(VALIDATION_CHAR_REGEX) && test.matches(VALIDATION_WHITESPACE_REGEX)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if a given string is a valid food name.
+     */
+    public static boolean isValidImportFoodName(String test) {
+        if (test.matches(VALIDATION_CHAR_REGEX_IMPORT) && test.matches(VALIDATION_WHITESPACE_REGEX)) {
             return true;
         } else {
             return false;
@@ -126,6 +138,10 @@ public class Food {
         this.proteins = proteins;
         updateKiloCalories();
         return this;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**

--- a/src/main/java/seedu/address/model/food/FoodIntake.java
+++ b/src/main/java/seedu/address/model/food/FoodIntake.java
@@ -21,6 +21,13 @@ public class FoodIntake {
                 temporaryFood.getProteins());
     }
 
+    public FoodIntake(LocalDate date, String name, double carbos, double fats, double proteins) {
+        this.date = date;
+        Food food = new Food("TEMP", carbos, fats, proteins);
+        food.setName(name);
+        this.food = food;
+    }
+
     public Food getFood() {
         return this.food;
     }

--- a/src/main/java/seedu/address/model/food/FoodIntake.java
+++ b/src/main/java/seedu/address/model/food/FoodIntake.java
@@ -21,6 +21,10 @@ public class FoodIntake {
                 temporaryFood.getProteins());
     }
 
+    /**
+     * Creates a FoodIntake object representing the Food consumed at a particular date and time.
+     * Used when loading from file.
+     */
     public FoodIntake(LocalDate date, String name, double carbos, double fats, double proteins) {
         this.date = date;
         Food food = new Food("TEMP", carbos, fats, proteins);

--- a/src/main/java/seedu/address/model/food/FoodIntakeList.java
+++ b/src/main/java/seedu/address/model/food/FoodIntakeList.java
@@ -41,6 +41,7 @@ public class FoodIntakeList {
             String foodNameWithCount = originalName + " " + (foodIntakeItemCount + 1);
             foodIntake = new FoodIntake(foodIntake.getDate(), foodNameWithCount, originalFood.getCarbos(), originalFood.getFats(), originalFood.getProteins());
         }
+        this.foodIntakeList.add(foodIntake);
     }
 
     /**

--- a/src/main/java/seedu/address/model/food/FoodIntakeList.java
+++ b/src/main/java/seedu/address/model/food/FoodIntakeList.java
@@ -4,6 +4,8 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -31,16 +33,38 @@ public class FoodIntakeList {
      * @param foodIntake FoodIntake object to add to list
      */
     public void addFoodIntake(FoodIntake foodIntake) {
-        this.foodIntakeList.add(foodIntake);
+        Food originalFood = foodIntake.getFood();
+        String originalName = getOriginalFoodName(originalFood.getName());
+        int foodIntakeItemCount = getFoodIntakeItemCount(foodIntake.getDate(), originalName);
+
+        if (foodIntakeItemCount != 0) {
+            String foodNameWithCount = originalName + " " + (foodIntakeItemCount + 1);
+            foodIntake = new FoodIntake(foodIntake.getDate(), foodNameWithCount, originalFood.getCarbos(), originalFood.getFats(), originalFood.getProteins());
+        }
     }
 
     /**
-     * Removes a FoodIntake item by index from the FoodIntakeList.
+     * Removes a FoodIntake item by the given date and foodintake name.
      *
-     * @param index index of food intake item
+     * @param date date of food intake
+     * @param date na,e pf fppd omtale
      */
-    public void deleteFoodIntake(int index) throws FoodIntakeNotFoundException {
-        this.foodIntakeList.remove(index);
+    public void deleteFoodIntake(LocalDate date, String name) throws FoodIntakeNotFoundException {
+        FoodIntake foodIntake;
+        boolean found = false;
+        for (int i = 0; i < this.getFoodIntakeList().size(); i++) {
+            foodIntake = this.foodIntakeList.get(i);
+            if (foodIntake.getDate().isEqual(date) && foodIntake.getFood().getName().equals(name)) {
+                this.foodIntakeList.remove(i);
+                reorderDuplicateFoodNames(date, name);
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            throw new FoodIntakeNotFoundException();
+        }
     }
 
     /**
@@ -66,6 +90,54 @@ public class FoodIntakeList {
             }
         }
         return -1;
+    }
+
+    /**
+     * Gets the number of FoodIntakes with the matching date and name
+     * @param date date to match for
+     * @param name name to match for
+     *
+     * @return count of matching FoodIntakes
+     */
+    public int getFoodIntakeItemCount(LocalDate date, String name) {
+        int count = 0;
+        FoodIntake foodIntake;
+        for (int i = 0; i < this.foodIntakeList.size(); i++) {
+            foodIntake = foodIntakeList.get(i);
+            if (foodIntake.getDate().isEqual(date) && getOriginalFoodName(foodIntake.getFood().getName()).equals(name)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    public String getOriginalFoodName(String name) {
+        Pattern pattern = Pattern.compile("(.*)( [0-9]*)$");
+        Matcher matcher = pattern.matcher(name);
+        int matchingCount = 0;
+
+        if (!matcher.matches()) {
+            return name;
+        } else {
+            return matcher.group(1);
+        }
+    }
+
+    public void reorderDuplicateFoodNames(LocalDate date, String name) {
+        String originalFoodName = getOriginalFoodName(name);
+        FoodIntake foodIntake;
+        int count = 1;
+        for (int i = 0; i < this.foodIntakeList.size(); i++) {
+            foodIntake = foodIntakeList.get(i);
+            if (foodIntake.getDate().isEqual(date) && getOriginalFoodName(foodIntake.getFood().getName()).equals(originalFoodName)) {
+                if (count == 1) {
+                    foodIntake.getFood().setName(originalFoodName);
+                } else {
+                    foodIntake.getFood().setName(originalFoodName + " " + count);
+                }
+                count++;
+            }
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/food/FoodIntakeList.java
+++ b/src/main/java/seedu/address/model/food/FoodIntakeList.java
@@ -39,7 +39,8 @@ public class FoodIntakeList {
 
         if (foodIntakeItemCount != 0) {
             String foodNameWithCount = originalName + " " + (foodIntakeItemCount + 1);
-            foodIntake = new FoodIntake(foodIntake.getDate(), foodNameWithCount, originalFood.getCarbos(), originalFood.getFats(), originalFood.getProteins());
+            foodIntake = new FoodIntake(foodIntake.getDate(), foodNameWithCount,
+                    originalFood.getCarbos(), originalFood.getFats(), originalFood.getProteins());
         }
         this.foodIntakeList.add(foodIntake);
     }
@@ -48,7 +49,7 @@ public class FoodIntakeList {
      * Removes a FoodIntake item by the given date and foodintake name.
      *
      * @param date date of food intake
-     * @param date na,e pf fppd omtale
+     * @param name name of food intake
      */
     public void deleteFoodIntake(LocalDate date, String name) throws FoodIntakeNotFoundException {
         FoodIntake foodIntake;
@@ -94,7 +95,7 @@ public class FoodIntakeList {
     }
 
     /**
-     * Gets the number of FoodIntakes with the matching date and name
+     * Gets the number of FoodIntakes with the matching date and name.
      * @param date date to match for
      * @param name name to match for
      *
@@ -105,13 +106,17 @@ public class FoodIntakeList {
         FoodIntake foodIntake;
         for (int i = 0; i < this.foodIntakeList.size(); i++) {
             foodIntake = foodIntakeList.get(i);
-            if (foodIntake.getDate().isEqual(date) && getOriginalFoodName(foodIntake.getFood().getName()).equals(name)) {
+            if (foodIntake.getDate().isEqual(date)
+                    && getOriginalFoodName(foodIntake.getFood().getName()).equals(name)) {
                 count++;
             }
         }
         return count;
     }
 
+    /**
+     * Gets the raw food name without the duplicate count.
+     */
     public String getOriginalFoodName(String name) {
         Pattern pattern = Pattern.compile("(.*)( [0-9]*)$");
         Matcher matcher = pattern.matcher(name);
@@ -124,13 +129,17 @@ public class FoodIntakeList {
         }
     }
 
+    /**
+     * Reorders duplicate food name counts for the given date and food name.
+     */
     public void reorderDuplicateFoodNames(LocalDate date, String name) {
         String originalFoodName = getOriginalFoodName(name);
         FoodIntake foodIntake;
         int count = 1;
         for (int i = 0; i < this.foodIntakeList.size(); i++) {
             foodIntake = foodIntakeList.get(i);
-            if (foodIntake.getDate().isEqual(date) && getOriginalFoodName(foodIntake.getFood().getName()).equals(originalFoodName)) {
+            if (foodIntake.getDate().isEqual(date)
+                    && getOriginalFoodName(foodIntake.getFood().getName()).equals(originalFoodName)) {
                 if (count == 1) {
                     foodIntake.getFood().setName(originalFoodName);
                 } else {

--- a/src/main/java/seedu/address/model/food/FoodIntakeList.java
+++ b/src/main/java/seedu/address/model/food/FoodIntakeList.java
@@ -18,6 +18,7 @@ import seedu.address.model.food.exceptions.FoodIntakeNotFoundException;
  */
 public class FoodIntakeList {
     private static final String DATE_FORMAT = "d MMM yyyy";
+    private static final String MATCH_DUPLICATE_COUNT_REGEX = "(.*)( [0-9]*)$";
     private ObservableList<FoodIntake> foodIntakeList;
 
     /**
@@ -118,9 +119,8 @@ public class FoodIntakeList {
      * Gets the raw food name without the duplicate count.
      */
     public String getOriginalFoodName(String name) {
-        Pattern pattern = Pattern.compile("(.*)( [0-9]*)$");
+        Pattern pattern = Pattern.compile(MATCH_DUPLICATE_COUNT_REGEX);
         Matcher matcher = pattern.matcher(name);
-        int matchingCount = 0;
 
         if (!matcher.matches()) {
             return name;

--- a/src/main/java/seedu/address/storage/JsonAdaptedFoodIntake.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedFoodIntake.java
@@ -60,7 +60,7 @@ public class JsonAdaptedFoodIntake {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     FoodIntake.class.getSimpleName()));
         }
-        if (!Food.isValidFoodName(name)) {
+        if (!Food.isValidImportFoodName(name)) {
             throw new IllegalValueException(String.format(INVALID_FIELD_MESSAGE_FORMAT,
                     FoodIntake.class.getSimpleName()));
         }
@@ -70,7 +70,7 @@ public class JsonAdaptedFoodIntake {
                     FoodIntake.class.getSimpleName()));
         }
 
-        return new FoodIntake(date, new Food(name, fats, carbos, proteins));
+        return new FoodIntake(date, name, fats, carbos, proteins);
     }
 
 }


### PR DESCRIPTION
When food intakes have the same name for a particular date, an identifier is added to the name for clarity and ease of updates and deletion. The previous implementation only allows for deletion of the first occurrence of the food name. This PR fixes the issue.

For example, when the user adds 3 'Chicken rice' to the food intake on the same date, they will be saved as:
Chicken rice
Chicken rice 2
Chicken rice 3

Resolved #100 