### PR TITLE
[Soh Jun Qi] Change parameters for calculateProgress method

### DIFF
--- a/src/main/java/seedu/address/logic/ProgressCalculator.java
+++ b/src/main/java/seedu/address/logic/ProgressCalculator.java
@@ -31,12 +31,13 @@ public class ProgressCalculator {
     /**
      * Calculates and reports on how much percentage of each day's food intake is adhering to the diet plan.
      *
-     * @param dietPlan The diet plan to calculate daily food intake against.
-     * @param foodIntakeList The food consumption for each day.
      * @param user User's information
      * @return Progress Report
      */
-    public static String calculateProgress(FoodIntakeList foodIntakeList, DietPlan dietPlan, User user) {
+    public static String calculateProgress(User user) {
+
+        FoodIntakeList foodIntakeList = user.getFoodIntakeList();
+        DietPlan dietPlan = user.getActiveDietPlan();
 
         // Get list of Foods
         List<FoodIntake> foodIntakes = initializeFoodIntake(foodIntakeList);

--- a/src/main/java/seedu/address/logic/commands/RunProgressCalculatorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RunProgressCalculatorCommand.java
@@ -6,7 +6,6 @@ import seedu.address.logic.ProgressCalculator;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.diet.DietPlan;
-import seedu.address.model.food.FoodIntakeList;
 import seedu.address.model.user.User;
 
 /**
@@ -37,10 +36,9 @@ public class RunProgressCalculatorCommand extends Command {
             throw new CommandException(MESSAGE_NO_DIET);
         }
 
-        FoodIntakeList foodIntakeList = model.getFoodIntakeList();
         User user = model.getUser();
 
-        String result = ProgressCalculator.calculateProgress(foodIntakeList, dietPlan, user);
+        String result = ProgressCalculator.calculateProgress(user);
 
         return new CommandResult(result);
 


### PR DESCRIPTION
The calculateProgress method of the ProgressCalculator class originally takes in 3 parameters which could have been reduced to 1 as they could be found in the User class.

Let's update the method to only require the User class object as a parameter