### PR TITLE
[Jason Lim] Address some PED concerns regarding Food Intakes and update User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -360,9 +360,13 @@ Update the nutrient value(s) of a previously entered food intake given the date 
 
 **Example:** `food_intake_update d/31 Mar 2021 n/tomato c/20 f/40 p/50`
 
-💡 **Tip:** Not all nutrient fields are required and only the specified nutrient fields will be updated with the new value while the other values remain unchanged.
+<div class="alert alert-info">
+  💡 **Tip:** Not all nutrient fields are required and only the specified nutrient fields will be updated with the new value while the other values remain unchanged.
+</div>
 
-❕ **Note:** At least one nutrient value is required.
+<div class="alert alert-danger">
+  ❕ **Note:** At least one nutrient value is required.
+</div>
 
 **Expected output:**
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -15,6 +15,7 @@ title: User Guide
 * [Introduction](#introduction)
 * [Understanding the User Guide](#understanding-the-user-guide)
 * [Quick start](#quick-start)
+* [Date format](#date-format)
 * [Features](#features)
 * [1. Body Mass Index (BMI) Tracker](#1-body-mass-index-bmi-tracker)
   * [1.1. Input weight, height and ideal weight](#11-input-weight-height-and-ideal-weight)
@@ -111,6 +112,19 @@ Legend | Description
    * **`progress`**: Shows your progress towards your ideal weight.
 
 6. Refer to the [Features](#features) section below for details of each command
+
+---
+
+## Date format
+DietLAH! uses the following date format for command inputs: `d MMM yyyy` which is clearer to interprete and reduces the chances of typos. Refer to the table below for more information:
+
+Legend | Description
+-------|-------------
+d | Day in the calendar, ranging from 0 - 31, without leading zeroes
+MMM | 3-letter textual representation of a month in the calendar, ranging from Jan - Dec
+yyyy | Numerical 4-digit year in the calendar, e.g. 2021
+
+Some example year inputs: `3 Jan 2021`, `21 Feb 2021`, `30 Mar 2021`
 
 ---
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -124,7 +124,7 @@ d | Day in the calendar month, ranging from 0 - 31, without leading zeroes
 MMM | 3-letter textual representation of a month in the calendar year, ranging from Jan - Dec, case sensitive
 yyyy | Numerical 4-digit representation of a year in the calendar, e.g. 2021
 
-Some example year inputs: `3 Jan 2021`, `21 Feb 2021`, `30 Mar 2021`
+Some example date inputs: `3 Jan 2021`, `21 Feb 2021`, `30 Mar 2021`
 
 ---
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -300,10 +300,12 @@ Deletes the specified food item.
 
 For tracking your diet plan progress, you are encouraged to record your daily food intake. For your convenience, there are a few ways to input a food intake. Refer to the different scenarios outlined below!
 
-❕ **Note:** If there are multiple food intakes with the same date and name, the food name will be automatically renamed to include a duplicate count for easy identification. E.g. Chicken rice, Chicken rice 2
+❕ **Note:** If there are multiple food intakes with the same date and name, the food name will be **automatically renamed** to include a duplicate count for easy identification. This is because there can be multiple food intakes for the same food in the given day, and they may contain different nutrient values.
+
+E.g. when you record two 'Chicken rice' in the food intake, they will appear as Chicken rice and Chicken rice #2 respectively.
 
 
-### 3.5.1 Input food intake (For new food items that are not created before)
+#### 3.5.1 Input food intake (For new food items that are not created before)
 
 Record your food intake for the specified date with a new food item not currently in your food list. The food will also be added to your food list for your convenience!
 
@@ -320,7 +322,7 @@ Record your food intake for the specified date with a new food item not currentl
 </p>
 
 
-### 3.5.2 Input food intake (For existing food items)
+#### 3.5.2 Input food intake (For existing food items)
 
 Record your food intake for the specified date using an existing food from your food list. Now you can save time having to re-enter your favourite food!
 
@@ -334,7 +336,7 @@ Record your food intake for the specified date using an existing food from your 
   <img src="images/user-guide/add-food-intake-new-food-item-result.png">
 </p>
 
-### 3.5.3 Input food intake (For existing food items, using different nutrient value(s))
+#### 3.5.3 Input food intake (For existing food items, using different nutrient value(s))
 
 Record your food intake for the specified date using an existing food from your food list, but with different nutrient value(s). The value(s) will also be updated in your food list.
 
@@ -359,6 +361,8 @@ Update the nutrient value(s) of a previously entered food intake given the date 
 **Example:** `food_intake_update d/31 Mar 2021 n/tomato c/20 f/40 p/50`
 
 💡 **Tip:** Not all nutrient fields are required and only the specified nutrient fields will be updated with the new value while the other values remain unchanged.
+
+❕ **Note:** At least one nutrient value is required.
 
 **Expected output:**
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -75,9 +75,9 @@ To make browsing the user guide more pleasant for you, here are some of the symb
 Legend | Description
 -------|-------------
 `Inline code` | Commands and user input
-[💡] | Tip - Extra information that may be useful
-[❕] | Note - Important things to take note of
-[❌] | Warning - Be extra careful with these
+<span class="alert alert-inline alert-tip">💡 <strong>Tip</strong></span> | Tip - Extra information that may be useful
+<span class="alert alert-inline alert-note">✏️<strong>Note</strong></span> | Note - Important things to take note of
+<span class="alert alert-inline alert-warning">⚠️ <strong>Warning</strong></span> | Warning - Be extra careful with these
 
 ## Quick start
 
@@ -126,8 +126,8 @@ When you first launch DietLAH!, you will be prompted to enter your particulars.
 
 DietLAH! uses this information to provide personalized recommendations based on your personal goals and current characteristics.
 
-<div class="alert alert-danger">
-    ❕ <strong>Note:</strong> You need to enter this command before all other commands will work!
+<div class="alert alert-note">
+    ✏️ <strong>Note:</strong> You need to enter this command before all other commands will work!
 </div>
 
 **Command Format:** `bmi g/GENDER a/AGE h/HEIGHT(CM) w/WEIGHT(KG) i/IDEAL_WEIGHT(KG)`
@@ -242,8 +242,8 @@ Save food items you frequently consume, so you don't have to re-enter them every
 
 **Example:** `food_add n/tomato c/10 f/10 p/10`
 
-<div class="alert alert-danger">
-  ❕ <strong>Note:</strong> Food names must be unique.
+<div class="alert alert-note">
+  ✏️ <strong>Note:</strong> Food names must be unique.
 </div>
 
 **Expected output:**
@@ -260,11 +260,11 @@ Update food items in your food list with new nutrition values.
 
 **Example:** `food_update n/tomato c/20 f/30 p/40`
 
-<div class="alert alert-danger">
-  ❕ <strong>Note:</strong> Ensure that the food item exists in the application.
+<div class="alert alert-note">
+  ✏️ <strong>Note:</strong> Ensure that the food item exists in the application.
 </div>
 
-<div class="alert alert-success">
+<div class="alert alert-tip">
 💡 <strong>Tip:</strong> Not all nutrient fields are compulsory. Save time from having to re-enter data and only include fields you wish to update!
 </div>
 
@@ -297,7 +297,7 @@ Deletes the specified food item.
 **Example:** `food_delete n/tomato`
 
 <div class="alert alert-warning">
-  ❌ <strong>Warning</strong> Deletion of a food item will not affect older food intake item records with similar name.
+  ⚠️ <strong>Warning</strong> Deletion of a food item will not affect older food intake item records with similar name.
 </div>
 
 **Expected output:**
@@ -310,8 +310,8 @@ Deletes the specified food item.
 
 For tracking your diet plan progress, you are encouraged to record your daily food intake. For your convenience, there are a few ways to input a food intake. Refer to the different scenarios outlined below!
 
-<div class="alert alert-danger">
-  ❕ <strong>Note:</strong> If there are multiple food intakes with the same date and name, the food name will be <strong>automatically renamed</strong> to include a duplicate count for easy identification. This is because there can be multiple food intakes for the same food in the given day, and they may contain different nutrient values. <br/><br/>
+<div class="alert alert-note">
+  ✏️ <strong>Note:</strong> If there are multiple food intakes with the same date and name, the food name will be <strong>automatically renamed</strong> to include a duplicate count for easy identification. This is because there can be multiple food intakes for the same food in the given day, and they may contain different nutrient values. <br/><br/>
 E.g. when you record two 'Chicken rice' in the food intake, they will appear as Chicken rice and Chicken rice #2 respectively.
 </div>
 
@@ -324,8 +324,8 @@ Record your food intake for the specified date with a new food item not currentl
 
 **Example:** `food_intake_add d/31 Mar 2021 n/tomato c/10 f/10 p/10`
 
-<div class="alert alert-danger">
-  ❕ <strong>Note:</strong> At least one nutrient value is required to create new food item. If a particular nutrient value is not provided, it will be set to 0 by default.
+<div class="alert alert-note">
+  ✏️ <strong>Note:</strong> At least one nutrient value is required to create new food item. If a particular nutrient value is not provided, it will be set to 0 by default.
 </div>
 
 **Expected output:**
@@ -357,8 +357,8 @@ Record your food intake for the specified date using an existing food from your 
 
 **Example:** `food_intake_add d/31 Mar 2021 n/tomato c/20 f/35 p/50`
 
-<div class="alert alert-danger">
-  ❕ <strong>Note:</strong> Any nutrient value(s) specified for an existing food item will be overwritten and updated in the food list for future use. Older food intake record(s) associated with the same food item will retain their original values.
+<div class="alert alert-note">
+  ✏️ <strong>Note:</strong> Any nutrient value(s) specified for an existing food item will be overwritten and updated in the food list for future use. Older food intake record(s) associated with the same food item will retain their original values.
 </div>
 
 **Expected output:**
@@ -375,12 +375,12 @@ Update the nutrient value(s) of a previously entered food intake given the date 
 
 **Example:** `food_intake_update d/31 Mar 2021 n/tomato c/20 f/40 p/50`
 
-<div class="alert alert-success">
+<div class="alert alert-tip">
   💡 <strong>Tip:</strong> Not all nutrient fields are required and only the specified nutrient fields will be updated with the new value while the other values remain unchanged.
 </div>
 
-<div class="alert alert-danger">
-  ❕ <strong>Note:</strong> At least one nutrient value is required.
+<div class="alert alert-note">
+  ✏️ <strong>Note:</strong> At least one nutrient value is required.
 </div>
 
 **Expected output:**
@@ -443,8 +443,8 @@ Generates a progress report based on your current active diet plan. Your food in
 
 **Command Format:** `progress`
 
-<div class="alert alert-danger">
-  ❕ <strong>Note:</strong> An active diet plan must be selected before running this command.
+<div class="alert alert-note">
+  ✏️ <strong>Note:</strong> An active diet plan must be selected before running this command.
 </div>
 
 **Expected output:**

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -397,6 +397,10 @@ Delete a food intake record from the application.
 
 **Example:** `food_intake_delete d/31 Mar 2021 n/tomato`
 
+<div class="alert alert-warning">
+  ⚠️ <strong>Warning</strong> After deletion of a food intake, if there are multiple food intake with the same name, their duplicate count will be reordered.
+</div>
+
 **Expected output:**
 
 <p align="center">

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -76,7 +76,7 @@ Legend | Description
 -------|-------------
 `Inline code` | Commands and user input
 <span class="alert alert-inline alert-tip">💡 <strong>Tip</strong></span> | Tip - Extra information that may be useful
-<span class="alert alert-inline alert-note">✏️<strong>Note</strong></span> | Note - Important things to take note of
+<span class="alert alert-inline alert-note">✏️ <strong>Note</strong></span> | Note - Important things to take note of
 <span class="alert alert-inline alert-warning">⚠️ <strong>Warning</strong></span> | Warning - Be extra careful with these
 
 ## Quick start

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -126,7 +126,9 @@ When you first launch DietLAH!, you will be prompted to enter your particulars.
 
 DietLAH! uses this information to provide personalized recommendations based on your personal goals and current characteristics.
 
-❕ **Note:** You need to enter this command before all other commands will work!
+<div class="alert alert-danger">
+    ❕ **Note:** You need to enter this command before all other commands will work!
+</div>
 
 **Command Format:** `bmi g/GENDER a/AGE h/HEIGHT(CM) w/WEIGHT(KG) i/IDEAL_WEIGHT(KG)`
 
@@ -240,7 +242,9 @@ Save food items you frequently consume, so you don't have to re-enter them every
 
 **Example:** `food_add n/tomato c/10 f/10 p/10`
 
-❕ **Note:** Food names must be unique.
+<div class="alert alert-danger">
+  ❕ **Note:** Food names must be unique.
+</div>
 
 **Expected output:**
 
@@ -256,9 +260,13 @@ Update food items in your food list with new nutrition values.
 
 **Example:** `food_update n/tomato c/20 f/30 p/40`
 
-❕ **Note:** Ensure that the food item exists in the application.
+<div class="alert alert-danger">
+  ❕ **Note:** Ensure that the food item exists in the application.
+</div>
 
+<div class="alert alert-success">
 💡 **Tip:** Not all nutrient fields are compulsory. Save time from having to re-enter data and only include fields you wish to update!
+</div>
 
 **Expected output:**
 
@@ -288,7 +296,9 @@ Deletes the specified food item.
 
 **Example:** `food_delete n/tomato`
 
-❌ **Warning:** Deletion of a food item will not affect older food intake item records with similar name.
+<div class="alert alert-warning">
+  ❌ **Warning:** Deletion of a food item will not affect older food intake item records with similar name.
+</div>
 
 **Expected output:**
 
@@ -300,9 +310,11 @@ Deletes the specified food item.
 
 For tracking your diet plan progress, you are encouraged to record your daily food intake. For your convenience, there are a few ways to input a food intake. Refer to the different scenarios outlined below!
 
-❕ **Note:** If there are multiple food intakes with the same date and name, the food name will be **automatically renamed** to include a duplicate count for easy identification. This is because there can be multiple food intakes for the same food in the given day, and they may contain different nutrient values.
+<div class="alert alert-danger">
+  ❕ **Note:** If there are multiple food intakes with the same date and name, the food name will be **automatically renamed** to include a duplicate count for easy identification. This is because there can be multiple food intakes for the same food in the given day, and they may contain different nutrient values.
 
 E.g. when you record two 'Chicken rice' in the food intake, they will appear as Chicken rice and Chicken rice #2 respectively.
+</div>
 
 
 #### 3.5.1 Input food intake (For new food items that are not created before)
@@ -313,7 +325,9 @@ Record your food intake for the specified date with a new food item not currentl
 
 **Example:** `food_intake_add d/31 Mar 2021 n/tomato c/10 f/10 p/10`
 
-❕ **Note:** At least one nutrient value is required to create new food item. If a particular nutrient value is not provided, it will be set to 0 by default.
+<div class="alert alert-danger">
+  ❕ **Note:** At least one nutrient value is required to create new food item. If a particular nutrient value is not provided, it will be set to 0 by default.
+</div>
 
 **Expected output:**
 
@@ -344,7 +358,9 @@ Record your food intake for the specified date using an existing food from your 
 
 **Example:** `food_intake_add d/31 Mar 2021 n/tomato c/20 f/35 p/50`
 
-❕ **Note:** Any nutrient value(s) specified for an existing food item will be overwritten and updated in the food list for future use. Older food intake record(s) associated with the same food item will retain their original values.
+<div class="alert alert-danger">
+  ❕ **Note:** Any nutrient value(s) specified for an existing food item will be overwritten and updated in the food list for future use. Older food intake record(s) associated with the same food item will retain their original values.
+</div>
 
 **Expected output:**
 
@@ -360,7 +376,7 @@ Update the nutrient value(s) of a previously entered food intake given the date 
 
 **Example:** `food_intake_update d/31 Mar 2021 n/tomato c/20 f/40 p/50`
 
-<div class="alert alert-info">
+<div class="alert alert-success">
   💡 **Tip:** Not all nutrient fields are required and only the specified nutrient fields will be updated with the new value while the other values remain unchanged.
 </div>
 
@@ -428,7 +444,9 @@ Generates a progress report based on your current active diet plan. Your food in
 
 **Command Format:** `progress`
 
-❕ **Note:** An active diet plan must be selected before running this command.
+<div class="alert alert-danger">
+  ❕ **Note:** An active diet plan must be selected before running this command.
+</div>
 
 **Expected output:**
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -127,7 +127,7 @@ When you first launch DietLAH!, you will be prompted to enter your particulars.
 DietLAH! uses this information to provide personalized recommendations based on your personal goals and current characteristics.
 
 <div class="alert alert-danger">
-    ❕ **Note:** You need to enter this command before all other commands will work!
+    ❕ <strong>Note:</strong> You need to enter this command before all other commands will work!
 </div>
 
 **Command Format:** `bmi g/GENDER a/AGE h/HEIGHT(CM) w/WEIGHT(KG) i/IDEAL_WEIGHT(KG)`
@@ -243,7 +243,7 @@ Save food items you frequently consume, so you don't have to re-enter them every
 **Example:** `food_add n/tomato c/10 f/10 p/10`
 
 <div class="alert alert-danger">
-  ❕ **Note:** Food names must be unique.
+  ❕ <strong>Note:</strong> Food names must be unique.
 </div>
 
 **Expected output:**
@@ -261,11 +261,11 @@ Update food items in your food list with new nutrition values.
 **Example:** `food_update n/tomato c/20 f/30 p/40`
 
 <div class="alert alert-danger">
-  ❕ **Note:** Ensure that the food item exists in the application.
+  ❕ <strong>Note:</strong> Ensure that the food item exists in the application.
 </div>
 
 <div class="alert alert-success">
-💡 **Tip:** Not all nutrient fields are compulsory. Save time from having to re-enter data and only include fields you wish to update!
+💡 <strong>Tip:</strong> Not all nutrient fields are compulsory. Save time from having to re-enter data and only include fields you wish to update!
 </div>
 
 **Expected output:**
@@ -297,7 +297,7 @@ Deletes the specified food item.
 **Example:** `food_delete n/tomato`
 
 <div class="alert alert-warning">
-  ❌ **Warning:** Deletion of a food item will not affect older food intake item records with similar name.
+  ❌ <strong>Warning</strong> Deletion of a food item will not affect older food intake item records with similar name.
 </div>
 
 **Expected output:**
@@ -311,8 +311,7 @@ Deletes the specified food item.
 For tracking your diet plan progress, you are encouraged to record your daily food intake. For your convenience, there are a few ways to input a food intake. Refer to the different scenarios outlined below!
 
 <div class="alert alert-danger">
-  ❕ **Note:** If there are multiple food intakes with the same date and name, the food name will be **automatically renamed** to include a duplicate count for easy identification. This is because there can be multiple food intakes for the same food in the given day, and they may contain different nutrient values.
-
+  ❕ <strong>Note:</strong> If there are multiple food intakes with the same date and name, the food name will be <strong>automatically renamed</strong> to include a duplicate count for easy identification. This is because there can be multiple food intakes for the same food in the given day, and they may contain different nutrient values. <br/><br/>
 E.g. when you record two 'Chicken rice' in the food intake, they will appear as Chicken rice and Chicken rice #2 respectively.
 </div>
 
@@ -326,7 +325,7 @@ Record your food intake for the specified date with a new food item not currentl
 **Example:** `food_intake_add d/31 Mar 2021 n/tomato c/10 f/10 p/10`
 
 <div class="alert alert-danger">
-  ❕ **Note:** At least one nutrient value is required to create new food item. If a particular nutrient value is not provided, it will be set to 0 by default.
+  ❕ <strong>Note:</strong> At least one nutrient value is required to create new food item. If a particular nutrient value is not provided, it will be set to 0 by default.
 </div>
 
 **Expected output:**
@@ -359,7 +358,7 @@ Record your food intake for the specified date using an existing food from your 
 **Example:** `food_intake_add d/31 Mar 2021 n/tomato c/20 f/35 p/50`
 
 <div class="alert alert-danger">
-  ❕ **Note:** Any nutrient value(s) specified for an existing food item will be overwritten and updated in the food list for future use. Older food intake record(s) associated with the same food item will retain their original values.
+  ❕ <strong>Note:</strong> Any nutrient value(s) specified for an existing food item will be overwritten and updated in the food list for future use. Older food intake record(s) associated with the same food item will retain their original values.
 </div>
 
 **Expected output:**
@@ -377,11 +376,11 @@ Update the nutrient value(s) of a previously entered food intake given the date 
 **Example:** `food_intake_update d/31 Mar 2021 n/tomato c/20 f/40 p/50`
 
 <div class="alert alert-success">
-  💡 **Tip:** Not all nutrient fields are required and only the specified nutrient fields will be updated with the new value while the other values remain unchanged.
+  💡 <strong>Tip:</strong> Not all nutrient fields are required and only the specified nutrient fields will be updated with the new value while the other values remain unchanged.
 </div>
 
 <div class="alert alert-danger">
-  ❕ **Note:** At least one nutrient value is required.
+  ❕ <strong>Note:</strong> At least one nutrient value is required.
 </div>
 
 **Expected output:**
@@ -445,7 +444,7 @@ Generates a progress report based on your current active diet plan. Your food in
 **Command Format:** `progress`
 
 <div class="alert alert-danger">
-  ❕ **Note:** An active diet plan must be selected before running this command.
+  ❕ <strong>Note:</strong> An active diet plan must be selected before running this command.
 </div>
 
 **Expected output:**

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -120,9 +120,9 @@ DietLAH! uses the following date format for command inputs: `d MMM yyyy` which i
 
 Legend | Description
 -------|-------------
-d | Day in the calendar, ranging from 0 - 31, without leading zeroes
-MMM | 3-letter textual representation of a month in the calendar, ranging from Jan - Dec
-yyyy | Numerical 4-digit year in the calendar, e.g. 2021
+d | Day in the calendar month, ranging from 0 - 31, without leading zeroes
+MMM | 3-letter textual representation of a month in the calendar year, ranging from Jan - Dec
+yyyy | Numerical 4-digit representation of a year in the calendar, e.g. 2021
 
 Some example year inputs: `3 Jan 2021`, `21 Feb 2021`, `30 Mar 2021`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -121,7 +121,7 @@ DietLAH! uses the following date format for command inputs: `d MMM yyyy` which i
 Legend | Description
 -------|-------------
 d | Day in the calendar month, ranging from 0 - 31, without leading zeroes
-MMM | 3-letter textual representation of a month in the calendar year, ranging from Jan - Dec
+MMM | 3-letter textual representation of a month in the calendar year, ranging from Jan - Dec, case sensitive
 yyyy | Numerical 4-digit representation of a year in the calendar, e.g. 2021
 
 Some example year inputs: `3 Jan 2021`, `21 Feb 2021`, `30 Mar 2021`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -116,7 +116,7 @@ Legend | Description
 ---
 
 ## Date format
-DietLAH! uses the following date format for command inputs: `d MMM yyyy` which is clearer to interprete and reduces the chances of typos. Refer to the table below for more information:
+DietLAH! uses the following date format for command inputs: `d MMM yyyy` which is clearer to interpret and reduces the chances of typos. Refer to the table below for more information:
 
 Legend | Description
 -------|-------------

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,5 +1,6 @@
 ---
 # Only the main Sass file needs front matter (the dashes are enough)
+# Alert CSS adapted from Bootstrap https://getbootstrap.com
 ---
 
 @import
@@ -9,4 +10,36 @@
 .icon {
     height: 21px;
     width: 21px
+}
+
+.alert {
+	position: relative;
+    padding: 1rem 1rem;
+    margin-bottom: 1rem;
+    border: 1px solid transparent;
+    border-radius: .25rem;
+}
+
+.alert-primary {
+    color: #084298;
+    background-color: #cfe2ff;
+    border-color: #b6d4fe;
+}
+
+.alert-warning {
+    color: #664d03;
+    background-color: #fff3cd;
+    border-color: #ffecb5;
+}
+
+.alert-danger {
+    color: #842029;
+    background-color: #f8d7da;
+    border-color: #f5c2c7;
+}
+
+.alert-primary {
+    color: #084298;
+    background-color: #cfe2ff;
+    border-color: #b6d4fe;
 }

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -20,7 +20,7 @@
     border-radius: .25rem;
 }
 
-.alert-primary {
+.alert-note {
     color: #084298;
     background-color: #cfe2ff;
     border-color: #b6d4fe;
@@ -32,14 +32,13 @@
     border-color: #ffecb5;
 }
 
-.alert-danger {
-    color: #842029;
-    background-color: #f8d7da;
-    border-color: #f5c2c7;
+.alert-tip {
+    color: #0f5132;
+    background-color: #d1e7dd;
+    border-color: #badbcc;
 }
 
-.alert-primary {
-    color: #084298;
-    background-color: #cfe2ff;
-    border-color: #b6d4fe;
+.alert-inline {
+	padding: 0!important;
+	display: inline;
 }

--- a/src/main/java/seedu/address/logic/FoodIntakeQueryProcessor.java
+++ b/src/main/java/seedu/address/logic/FoodIntakeQueryProcessor.java
@@ -39,7 +39,8 @@ public class FoodIntakeQueryProcessor {
             counter++;
         }
         foodIntakeCalculator = new FoodIntakeCalculator(carbos, fats, proteins);
-        stringBuilder.append("\nTotal Daily Calories Intake: " + String.format("%.2f", foodIntakeCalculator.getCalories())
+        stringBuilder.append("\nTotal Daily Calories Intake: "
+                + String.format("%.2f", foodIntakeCalculator.getCalories())
                 + " calories.\n");
         return stringBuilder.toString();
     }

--- a/src/main/java/seedu/address/logic/FoodIntakeQueryProcessor.java
+++ b/src/main/java/seedu/address/logic/FoodIntakeQueryProcessor.java
@@ -39,7 +39,7 @@ public class FoodIntakeQueryProcessor {
             counter++;
         }
         foodIntakeCalculator = new FoodIntakeCalculator(carbos, fats, proteins);
-        stringBuilder.append("Total Daily Calories Intake: " + String.format("%.2f", foodIntakeCalculator.getCalories())
+        stringBuilder.append("\nTotal Daily Calories Intake: " + String.format("%.2f", foodIntakeCalculator.getCalories())
                 + " calories.\n");
         return stringBuilder.toString();
     }

--- a/src/main/java/seedu/address/logic/commands/AddFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddFoodIntakeCommand.java
@@ -49,7 +49,7 @@ public class AddFoodIntakeCommand extends Command {
         int index = model.getUniqueFoodList().getFoodItemIndex(this.tempFoodDescriptor.getName().get());
         boolean skipEditCheck = false;
 
-        //Food does not exist in Unique Food List, hence add the food item in.
+        //Food does not exist in Unique Food List, add to Unique Food List
         if (index == -1) {
             Food newFood = createNewFood(this.tempFoodDescriptor);
             model.addFoodItem(newFood);
@@ -62,15 +62,21 @@ public class AddFoodIntakeCommand extends Command {
         if (!skipEditCheck && (this.tempFoodDescriptor.getCarbos().isPresent()
                 || this.tempFoodDescriptor.getFats().isPresent()
                 || this.tempFoodDescriptor.getProteins().isPresent())) {
-            Food edittedFood = editCurrentFood(food, tempFoodDescriptor);
-            model.getUniqueFoodList().getFoodList().set(index, edittedFood);
-            model.addFoodIntake(this.date, edittedFood);
-            return new CommandResult(MESSAGE_SUCCESS_FOOD_UPDATE + edittedFood + ".\n"
-                    + MESSAGE_SUCCESS + edittedFood + ") into food intake list.");
+
+            Food editedFood = editCurrentFood(food, tempFoodDescriptor);
+            model.getUniqueFoodList().getFoodList().set(index, editedFood);
+
+            Food addedFood = model.addFoodIntake(this.date, editedFood);
+            String updateFoodIntakeList = model.getFoodIntakeList().getFoodIntakeListByDate(date);
+
+            return new CommandResult( MESSAGE_SUCCESS_FOODINTAKE_ADD + ": \n"
+                    + addedFood + "\n\n" + MESSAGE_SUCCESS_FOOD_UPDATE + "\n\n" + updateFoodIntakeList);
         }
 
-        model.addFoodIntake(this.date, food);
-        return new CommandResult(MESSAGE_SUCCESS + food + ") into food intake list.");
+        Food addedFood = model.addFoodIntake(this.date, food);
+        String updateFoodIntakeList = model.getFoodIntakeList().getFoodIntakeListByDate(date);
+
+        return new CommandResult(MESSAGE_SUCCESS_FOODINTAKE_ADD + ": \n" + addedFood + "\n\n" + updateFoodIntakeList);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddFoodIntakeCommand.java
@@ -27,7 +27,8 @@ public class AddFoodIntakeCommand extends Command {
     public static final String MESSAGE_FAILURE_CREATE_FOOD_REQ = "Suggested food item not found. Please append at "
             + "least 1 nutrient value to add the food item. (Eg. c/CARBOS(g) or f/FATS(g) or p/PROTEINS(g) ";
 
-    public static final String MESSAGE_SUCCESS_FOOD_UPDATE = "For your convenience, we have also updated the nutrient values in your food list.";
+    public static final String MESSAGE_SUCCESS_FOOD_UPDATE = "For your convenience, "
+            + "we have also updated the nutrient values in your food list.";
 
     public static final String MESSAGE_SUCCESS_FOODINTAKE_ADD = "Successfully recorded food intake";
 
@@ -69,7 +70,7 @@ public class AddFoodIntakeCommand extends Command {
             Food addedFood = model.addFoodIntake(this.date, editedFood);
             String updateFoodIntakeList = model.getFoodIntakeList().getFoodIntakeListByDate(date);
 
-            return new CommandResult( MESSAGE_SUCCESS_FOODINTAKE_ADD + ": \n"
+            return new CommandResult(MESSAGE_SUCCESS_FOODINTAKE_ADD + ": \n"
                     + addedFood + "\n\n" + MESSAGE_SUCCESS_FOOD_UPDATE + "\n\n" + updateFoodIntakeList);
         }
 

--- a/src/main/java/seedu/address/logic/commands/AddFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddFoodIntakeCommand.java
@@ -24,12 +24,12 @@ public class AddFoodIntakeCommand extends Command {
             + "3. Input food intake (For existing food items, using different nutrient value(s))\n"
             + "Command usage: food_intake_add d/DATE(in d MMM yyyy format) n/FOOD_NAME c/CARBOS f/FATS p/PROTEINS\n";
 
-    public static final String MESSAGE_SUCCESS = "Success adding food item (";
-
     public static final String MESSAGE_FAILURE_CREATE_FOOD_REQ = "Suggested food item not found. Please append at "
             + "least 1 nutrient value to add the food item. (Eg. c/CARBOS(g) or f/FATS(g) or p/PROTEINS(g) ";
 
-    public static final String MESSAGE_SUCCESS_FOOD_UPDATE = "Successfully edited food value to: ";
+    public static final String MESSAGE_SUCCESS_FOOD_UPDATE = "For your convenience, we have also updated the nutrient values in your food list.";
+
+    public static final String MESSAGE_SUCCESS_FOODINTAKE_ADD = "Successfully recorded food intake";
 
     private final LocalDate date;
 

--- a/src/main/java/seedu/address/logic/commands/DeleteFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteFoodIntakeCommand.java
@@ -46,9 +46,10 @@ public class DeleteFoodIntakeCommand extends Command {
 
         try {
             foodIntakeList.deleteFoodIntake(this.date, this.foodName);
-            return new CommandResult(MESSAGE_DELETE_FOOD_SUCCESS + " " + this.foodName);
+            String updateFoodIntakeList = model.getFoodIntakeList().getFoodIntakeListByDate(this.date);
+            return new CommandResult(MESSAGE_DELETE_FOODINTAKE_SUCCESS + " " + this.foodName + "\n\n" + updateFoodIntakeList);
         } catch (FoodIntakeNotFoundException exception) {
-            throw new CommandException(MESSAGE_DELETE_FOOD_FAILURE);
+            throw new CommandException(MESSAGE_DELETE_FOODINTAKE_FAILURE);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteFoodIntakeCommand.java
@@ -19,10 +19,10 @@ public class DeleteFoodIntakeCommand extends Command {
             + ": This deletes the food intake item identified by its name on that date.\n"
             + "Command usage: food_intake_delete d/DATE(in d MMM yyyy format) n/FOOD_NAME";
 
-    public static final String MESSAGE_DELETE_FOOD_SUCCESS = "Successfully deleted food intake: ";
+    public static final String MESSAGE_DELETE_FOODINTAKE_SUCCESS = "Successfully deleted food intake: ";
 
-    public static final String MESSAGE_DELETE_FOOD_FAILURE = "Food intake could not be found. Please ensure its name "
-            + "and date provided are correct.";
+    public static final String MESSAGE_DELETE_FOODINTAKE_FAILURE = "Food intake could not be found. Please verify that the name "
+            + "and date provided is correct.";
 
     private final String foodName;
 

--- a/src/main/java/seedu/address/logic/commands/DeleteFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteFoodIntakeCommand.java
@@ -21,8 +21,8 @@ public class DeleteFoodIntakeCommand extends Command {
 
     public static final String MESSAGE_DELETE_FOODINTAKE_SUCCESS = "Successfully deleted food intake: ";
 
-    public static final String MESSAGE_DELETE_FOODINTAKE_FAILURE = "Food intake could not be found. Please verify that the name "
-            + "and date provided is correct.";
+    public static final String MESSAGE_DELETE_FOODINTAKE_FAILURE = "Food intake could not be found. "
+            + "Please verify that the name and date provided is correct.";
 
     private final String foodName;
 
@@ -47,7 +47,8 @@ public class DeleteFoodIntakeCommand extends Command {
         try {
             foodIntakeList.deleteFoodIntake(this.date, this.foodName);
             String updateFoodIntakeList = model.getFoodIntakeList().getFoodIntakeListByDate(this.date);
-            return new CommandResult(MESSAGE_DELETE_FOODINTAKE_SUCCESS + " " + this.foodName + "\n\n" + updateFoodIntakeList);
+            return new CommandResult(MESSAGE_DELETE_FOODINTAKE_SUCCESS + " "
+                    + this.foodName + "\n\n" + updateFoodIntakeList);
         } catch (FoodIntakeNotFoundException exception) {
             throw new CommandException(MESSAGE_DELETE_FOODINTAKE_FAILURE);
         }

--- a/src/main/java/seedu/address/logic/commands/UpdateFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateFoodIntakeCommand.java
@@ -61,9 +61,11 @@ public class UpdateFoodIntakeCommand extends Command {
             throw new CommandException(MESSAGE_FAILURE);
         }
 
+        // Retain original values as date and name are not editable.
         this.date = currentFoodIntake.getDate();
         this.name = currentFoodIntake.getFood().getName();
 
+        // Replace nutrient values, if they were provided
         this.fats = replaceUpdatedValue(currentFoodIntake.getFood().getFats(), this.fats);
         this.carbos = replaceUpdatedValue(currentFoodIntake.getFood().getCarbos(), this.carbos);
         this.proteins = replaceUpdatedValue(currentFoodIntake.getFood().getProteins(), this.proteins);

--- a/src/main/java/seedu/address/logic/commands/UpdateFoodIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateFoodIntakeCommand.java
@@ -18,16 +18,20 @@ public class UpdateFoodIntakeCommand extends Command {
             + ": This updates the nutritional values for a particular date and food.\n"
             + "Command usage: food_intake_update d/DATE(in d MMM yyyy format) n/FOOD_NAME c/CARBOS f/FATS p/PROTEINS";
 
-    public static final String MESSAGE_SUCCESS = "Food intake successfully updated for ";
+    public static final String MESSAGE_SUCCESS = "Food intake successfully updated for:";
 
     public static final String MESSAGE_FAILURE = "Unable to find food intake record. Are you trying "
             + "to add a new intake?";
+
+    public static final String MESSAGE_NUTRIENTS_REQUIRED = "Please specify at least 1 nutrient value to be updated.";
+    public static final int EDITABLE_NUTRIENT_COUNT = 3;
 
     private String name;
     private LocalDate date;
     private String fats;
     private String carbos;
     private String proteins;
+    private int nutrientsEdited = 0;
 
     /**
      * Creates an UpdateFoodIntake command to update existing foodIntakes.
@@ -60,22 +64,31 @@ public class UpdateFoodIntakeCommand extends Command {
         this.date = currentFoodIntake.getDate();
         this.name = currentFoodIntake.getFood().getName();
 
-        if (this.fats == null) {
-            this.fats = String.valueOf(currentFoodIntake.getFood().getFats());
-        }
+        this.fats = replaceUpdatedValue(currentFoodIntake.getFood().getFats(), this.fats);
+        this.carbos = replaceUpdatedValue(currentFoodIntake.getFood().getCarbos(), this.carbos);
+        this.proteins = replaceUpdatedValue(currentFoodIntake.getFood().getProteins(), this.proteins);
 
-        if (this.carbos == null) {
-            this.carbos = String.valueOf(currentFoodIntake.getFood().getCarbos());
-        }
-
-        if (this.proteins == null) {
-            this.proteins = String.valueOf(currentFoodIntake.getFood().getProteins());
+        if (nutrientsEdited == 0) {
+            throw new CommandException(MESSAGE_NUTRIENTS_REQUIRED);
         }
 
         newFoodIntake = new FoodIntake(this.date, this.name,
                 Double.parseDouble(this.carbos), Double.parseDouble(this.fats),
                 Double.parseDouble(this.proteins));
         model.updateFoodIntake(index, newFoodIntake);
-        return new CommandResult(MESSAGE_SUCCESS + "(" + this.name + ")");
+
+        String updateFoodIntakeList = model.getFoodIntakeList().getFoodIntakeListByDate(this.date);
+        return new CommandResult(MESSAGE_SUCCESS + " " + this.name + "\n\n" + updateFoodIntakeList);
+    }
+
+    /**
+     * Returns current existing value if no updated value provided.
+     */
+    public String replaceUpdatedValue(Double current, String updated) {
+        if (updated == null) {
+            return String.valueOf(current);
+        }
+        nutrientsEdited++;
+        return updated;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteFoodIntakeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteFoodIntakeCommandParser.java
@@ -42,7 +42,7 @@ public class DeleteFoodIntakeCommandParser implements Parser<DeleteFoodIntakeCom
             throw new ParseException(String.format(MESSAGE_INVALID_DATETIME_FORMAT,
                     DeleteFoodIntakeCommand.MESSAGE_USAGE));
         }
-        foodName = ParserUtil.parseFoodName(argMultimap.getValue(PREFIX_NAME).get());
+        foodName = ParserUtil.parseFoodIntakeName(argMultimap.getValue(PREFIX_NAME).get());
         return new DeleteFoodIntakeCommand(date, foodName);
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -99,6 +99,23 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a {@code String name} to conform with a FoodIntake Food name.
+     * Allows the '#' character that takes into account for duplicate names.
+     * Called only during FoodIntake Update and delete.
+     *
+     * @throws ParseException if the given {@code name} is invalid.
+     */
+    public static String parseFoodIntakeName(String name) throws ParseException {
+        requireNonNull(name);
+        String trimmedName = name.trim();
+        if (!trimmedName.matches(Food.VALIDATION_CHAR_REGEX_IMPORT)
+                || trimmedName.length() == 0) {
+            throw new ParseException(Food.MESSAGE_CONSTRAINTS);
+        }
+        return trimmedName;
+    }
+
+    /**
      * Parses a {@code String ageString} into an Integer.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/seedu/address/logic/parser/UpdateFoodIntakeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UpdateFoodIntakeCommandParser.java
@@ -35,7 +35,7 @@ public class UpdateFoodIntakeCommandParser implements Parser<UpdateFoodIntakeCom
         String fats;
         String proteins;
 
-        String name = ParserUtil.parseFoodName(argMultimap.getValue(PREFIX_NAME).get());
+        String name = ParserUtil.parseFoodIntakeName(argMultimap.getValue(PREFIX_NAME).get());
         LocalDate date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
 
         if (!isPrefixPresent(argMultimap, PREFIX_CARBOS)) {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -226,16 +226,16 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Replaces the given person {@code target} in the list with {@code editedPerson}.
-     * {@code target} must exist in the address book.
-     * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
-     * Adds food intake object into the food intake list.
+     * Adds a FoodIntake to the FoodIntakeList given the date and Food
+     * The FoodIntake's Food name may be appended with a duplicate count.
      *
-     * @param date date of food intake object
-     * @param food food item of food intake object
+     * @param date date of Food intake object
+     * @param food food item of Food intake object
+     *
+     * @return Food that was successfully added to the FoodIntakeList.
      */
-    public void addFoodIntake(LocalDate date, Food food) {
-        foodIntakeList.addFoodIntake(new FoodIntake(date, food));
+    public Food addFoodIntake(LocalDate date, Food food) {
+        return foodIntakeList.addFoodIntake(new FoodIntake(date, food));
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -119,11 +119,13 @@ public interface Model {
     //=========== FoodIntakeList Accessors ==============================================================
 
     /**
-     * Adds the food consumed on the day to the food intake list.
+     * Adds the Food consumed on the specified day to the food intake list.
      * @param date date of intake
      * @param food food object
+     *
+     * @return Food that was successfully added to FoodIntakeList
      */
-    void addFoodIntake(LocalDate date, Food food);
+    Food addFoodIntake(LocalDate date, Food food);
 
     /**
      * Updates the FoodIntake object in the FoodIntakeList

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -281,8 +281,8 @@ public class ModelManager implements Model {
     //=========== FoodIntakeList Accessors =============================================================
 
     @Override
-    public void addFoodIntake(LocalDate date, Food food) {
-        addressBook.addFoodIntake(date, food);
+    public Food addFoodIntake(LocalDate date, Food food) {
+        return addressBook.addFoodIntake(date, food);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/food/Food.java
+++ b/src/main/java/seedu/address/model/food/Food.java
@@ -9,7 +9,7 @@ public class Food {
     public static final double FAT_MULTIPLIER = 9; //Conversion to KCAL
     public static final String VALIDATION_WHITESPACE_REGEX = "[^\\s].*";
     public static final String VALIDATION_CHAR_REGEX = "[a-zA-Z0-9\\s]*";
-    public static final String VALIDATION_CHAR_REGEX_IMPORT = "[a-zA-Z0-9 ]*";
+    public static final String VALIDATION_CHAR_REGEX_IMPORT = "[a-zA-Z0-9# ]*";
     public static final String VALIDATION_POSITIVE_DOUBLE_REGEX = "(\\d*\\.?\\d+)";
     public static final String MESSAGE_CONSTRAINTS = "Food name can take only alphanumeric character "
             + "and it should not be empty.";

--- a/src/main/java/seedu/address/model/food/FoodIntakeList.java
+++ b/src/main/java/seedu/address/model/food/FoodIntakeList.java
@@ -21,6 +21,7 @@ import seedu.address.model.util.TemplateInitializer;
  */
 public class FoodIntakeList {
     private static final String DATE_FORMAT = "d MMM yyyy";
+    private static final String DUPLICATE_COUNT_PREFIX = "#";
     private static final String MATCH_DUPLICATE_COUNT_REGEX = "(.*)( #[0-9]*)$";
     private ObservableList<FoodIntake> foodIntakeList;
 
@@ -47,7 +48,7 @@ public class FoodIntakeList {
         int foodIntakeItemCount = getFoodIntakeItemCount(foodIntake.getDate(), originalName);
 
         if (foodIntakeItemCount != 0) {
-            String foodNameWithCount = originalName + " #" + (foodIntakeItemCount + 1);
+            String foodNameWithCount = originalName + " " + DUPLICATE_COUNT_PREFIX + (foodIntakeItemCount + 1);
             foodIntake = new FoodIntake(foodIntake.getDate(), foodNameWithCount,
                     originalFood.getCarbos(), originalFood.getFats(), originalFood.getProteins());
         }
@@ -66,6 +67,7 @@ public class FoodIntakeList {
         requireNonNull(date);
         requireNonNull(name);
         FoodIntake foodIntake;
+
         boolean found = false;
         for (int i = 0; i < this.getFoodIntakeList().size(); i++) {
             foodIntake = this.foodIntakeList.get(i);
@@ -162,7 +164,7 @@ public class FoodIntakeList {
                 if (count == 1) {
                     foodIntake.getFood().setName(originalFoodName);
                 } else {
-                    foodIntake.getFood().setName(originalFoodName + " " + count);
+                    foodIntake.getFood().setName(originalFoodName + " " + DUPLICATE_COUNT_PREFIX + count);
                 }
                 count++;
             }

--- a/src/main/java/seedu/address/model/food/FoodIntakeList.java
+++ b/src/main/java/seedu/address/model/food/FoodIntakeList.java
@@ -21,7 +21,7 @@ import seedu.address.model.util.TemplateInitializer;
  */
 public class FoodIntakeList {
     private static final String DATE_FORMAT = "d MMM yyyy";
-    private static final String MATCH_DUPLICATE_COUNT_REGEX = "(.*)( [0-9]*)$";
+    private static final String MATCH_DUPLICATE_COUNT_REGEX = "(.*)( #[0-9]*)$";
     private ObservableList<FoodIntake> foodIntakeList;
 
     /**
@@ -32,26 +32,32 @@ public class FoodIntakeList {
     }
 
     /**
-     * Adds a FoodIntake object to the FoodIntakeList.
+     * Adds a FoodIntake object to the FoodIntakeList and retuns final FoodIntake food name.
+     * The FoodIntake's Food name may have been appended with a duplicate count.
      *
      * @param foodIntake FoodIntake object to add to list
+     *
+     * @return final FoodIntake added to FoodIntakeList
      */
-    public void addFoodIntake(FoodIntake foodIntake) {
+    public Food addFoodIntake(FoodIntake foodIntake) {
         assert foodIntake != null : "FoodIntake cannot be null";
+
         Food originalFood = foodIntake.getFood();
         String originalName = getOriginalFoodName(originalFood.getName());
         int foodIntakeItemCount = getFoodIntakeItemCount(foodIntake.getDate(), originalName);
 
         if (foodIntakeItemCount != 0) {
-            String foodNameWithCount = originalName + " " + (foodIntakeItemCount + 1);
+            String foodNameWithCount = originalName + " #" + (foodIntakeItemCount + 1);
             foodIntake = new FoodIntake(foodIntake.getDate(), foodNameWithCount,
                     originalFood.getCarbos(), originalFood.getFats(), originalFood.getProteins());
         }
         this.foodIntakeList.add(foodIntake);
+
+        return foodIntake.getFood();
     }
 
     /**
-     * Removes a FoodIntake item by the given date and foodintake name.
+     * Removes a FoodIntake item by the given date and FoodIntake Food name.
      *
      * @param date date of food intake
      * @param name name of food intake

--- a/src/test/java/seedu/address/logic/commands/AddFoodItemCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddFoodItemCommandTest.java
@@ -162,7 +162,7 @@ public class AddFoodItemCommandTest {
         }
 
         @Override
-        public void addFoodIntake(LocalDate date, Food food) {
+        public Food addFoodIntake(LocalDate date, Food food) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
Changed FoodIntake duplicate count to use `#Count` instead of the initial `Count` (e.g. `Chicken rice`, `Chicken rice #2`) as Food names can now contain numbers due to relaxation of Food names in #189

Updated some FoodIntake Commands to automatically list Food Intakes after add, update, delete commands to resolve #181

Updated User Guide to reflect concerns from PED on duplicate count #164

Updated User Guide to show tips/warnings/notes in alerts

Updated User Guide to include date format section