### PR TITLE
[Soh Jun Qi] Fix confusing identifiers for plan_recommend

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RecommendPlanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RecommendPlanCommand.java
@@ -3,9 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;

--- a/src/main/java/seedu/address/logic/commands/RecommendPlanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RecommendPlanCommand.java
@@ -2,7 +2,10 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -24,10 +27,9 @@ public class RecommendPlanCommand extends Command {
 
     }
 
-    private void appendDiets(StringBuilder recommendations, List<DietPlan> recommendedDiets) {
-        for (int count = 0; count < recommendedDiets.size(); count++) {
-            int index = count + 1;
-            DietPlan dietPlan = recommendedDiets.get(count);
+    private void appendDiets(StringBuilder recommendations, HashMap<Integer, DietPlan> recommendedDiets) {
+        for (Integer index : recommendedDiets.keySet()) {
+            DietPlan dietPlan = recommendedDiets.get(index);
             recommendations.append(index + ". " + dietPlan.getPlanName() + "\n");
         }
     }
@@ -37,7 +39,7 @@ public class RecommendPlanCommand extends Command {
         requireNonNull(model);
 
         PlanType userGoal = model.getUserGoal();
-        List<DietPlan> recommendedDiets = model.recommendDiets(userGoal);
+        HashMap<Integer, DietPlan> recommendedDiets = model.recommendDiets(userGoal);
 
         StringBuilder recommendations = new StringBuilder("Here are the recommended ");
         switch (userGoal) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -2,8 +2,8 @@ package seedu.address.model;
 
 import java.nio.file.Path;
 import java.time.LocalDate;
-import java.util.function.Predicate;
 import java.util.HashMap;
+import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -2,8 +2,8 @@ package seedu.address.model;
 
 import java.nio.file.Path;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.function.Predicate;
+import java.util.HashMap;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
@@ -114,7 +114,7 @@ public interface Model {
     DietPlan getActiveDiet();
 
     /** Recommend diet plan based on user's goals*/
-    List<DietPlan> recommendDiets(PlanType planType);
+    HashMap<Integer, DietPlan> recommendDiets(PlanType planType);
 
     //=========== FoodIntakeList Accessors ==============================================================
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.HashMap;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -315,14 +316,16 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public List<DietPlan> recommendDiets(PlanType planType) {
-        List<DietPlan> recommendedDiets = new ArrayList<>();
+    public HashMap<Integer, DietPlan> recommendDiets(PlanType planType) {
+        HashMap<Integer, DietPlan> recommendedDiets = new HashMap<>();
         Iterator<DietPlan> iterator = dietPlanList.iterator();
+        int counter = 1;
         while (iterator.hasNext()) {
             DietPlan dietPlan = iterator.next();
             if (dietPlan.getPlanType() == planType) {
-                recommendedDiets.add(dietPlan);
+                recommendedDiets.put(new Integer(counter), dietPlan);
             }
+            counter++;
         }
         return recommendedDiets;
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -5,11 +5,9 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.function.Predicate;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;

--- a/src/test/java/seedu/address/logic/commands/AddFoodItemCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddFoodItemCommandTest.java
@@ -8,8 +8,8 @@ import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 import java.util.HashMap;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/AddFoodItemCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddFoodItemCommandTest.java
@@ -8,8 +8,8 @@ import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.function.Predicate;
+import java.util.HashMap;
 
 import org.junit.jupiter.api.Test;
 
@@ -157,7 +157,7 @@ public class AddFoodItemCommandTest {
         }
 
         @Override
-        public List<DietPlan> recommendDiets(PlanType planType) {
+        public HashMap<Integer, DietPlan> recommendDiets(PlanType planType) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
As per issue #155 , the plan_recommend command generates a list of recommended diet plans. However, the diet plans are listed in ascending order and can cause confusion as it is not the exact identifier used for the plan.

Let's change the output of the plan_recommend command to reflect the true identifier of each plan