### PR TITLE
[Soh Jun Qi] Fix bug with processing of trailing zeros in bmi commands

### DIFF
--- a/src/main/java/seedu/address/model/user/Bmi.java
+++ b/src/main/java/seedu/address/model/user/Bmi.java
@@ -9,7 +9,7 @@ public class Bmi {
                     + " and may include a decimal.";
     private static final double HEALTHY_BMI_LOWER_BOUND = 18.5;
     private static final double HEALTHY_BMI_UPPER_BOUND = 22.9;
-    private static final String VALIDATION_REGEX = "^[1-9](\\d+)?$|^[1-9](\\d+)?.(\\d+)$";
+    private static final String VALIDATION_REGEX = "^(0)*[1-9](\\d+)?$|^(0)*[1-9](\\d+)?.(\\d+)$";
 
     // Identity fields
 

--- a/src/main/java/seedu/address/model/user/IdealWeight.java
+++ b/src/main/java/seedu/address/model/user/IdealWeight.java
@@ -7,7 +7,7 @@ public class IdealWeight {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Ideal Weight should be in kilograms, greater than 1 and may include a decimal!";
-    private static final String VALIDATION_REGEX = "^[1-9](\\d+)?$|^[1-9](\\d+)?.(\\d+)$";
+    private static final String VALIDATION_REGEX = "^(0)*[1-9](\\d+)?$|^(0)*[1-9](\\d+)?.(\\d+)$";
     private double idealWeight;
 
     public IdealWeight() {


### PR DESCRIPTION
As per issue #157, trailing zeros in front of double values are not accepted. This is something that can be improved on.

Let's update DietLah to accept trailing zeros in bmi and bmi_update commands.